### PR TITLE
Fix wrong reportID usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: Build XLAT firmware
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     branches:
-      - main
+      - '**'
 
 jobs:
   build:

--- a/src/gfx_main.c
+++ b/src/gfx_main.c
@@ -289,9 +289,9 @@ void gfx_set_byte_offsets_text(void)
     uint8_t               interface = xlat_get_found_interface();
 
     if (button->found && x->found && y->found && XLAT_MODE_KEY != xlat_get_mode()) {
-        sprintf(text, "Mouse Data (#%d): click@%d motion@%d,%d", interface, button->byte_offset, x->byte_offset, y->byte_offset);
+        sprintf(text, "Mouse Data (#%d): id@%d click@%d motion@%d,%d", interface, xlat_get_reportid(), button->byte_offset, x->byte_offset, y->byte_offset);
     } else if (key->found && XLAT_MODE_KEY == xlat_get_mode()) {
-        sprintf(text, "Keyboard Data (#%d): pressed@%d", interface, key->byte_offset);
+        sprintf(text, "Keyboard Data (#%d): id@%d pressed@%d", interface, xlat_get_reportid(), key->byte_offset);
     } else {
         // offsets not found
         sprintf(text, "Data: offsets not found");

--- a/src/gfx_main.c
+++ b/src/gfx_main.c
@@ -294,7 +294,7 @@ void gfx_set_byte_offsets_text(void)
         sprintf(text, "Keyboard Data (#%d): id@%d pressed@%d", interface, xlat_get_reportid(), key->byte_offset);
     } else {
         // offsets not found
-        sprintf(text, "Data: offsets not found");
+        sprintf(text, (XLAT_MODE_KEY == xlat_get_mode()) ? "Keyboard Data: offsets not found" : "Mouse Data: offsets not found");
     }
 
     lv_checkbox_set_text(hid_offsets_label, text);

--- a/src/usb/usb_host.c
+++ b/src/usb/usb_host.c
@@ -82,6 +82,7 @@ static void USBH_UserProcess  (USBH_HandleTypeDef *phost, uint8_t id)
             break;
         }
 
+        case HOST_USER_NO_SUPPORTED_CLASS:
         case HOST_USER_CLASS_ACTIVE: {
             // Compose vidpid string
             uint16_t vid = phost->device.DevDesc.idVendor;

--- a/src/usb/usb_host.c
+++ b/src/usb/usb_host.c
@@ -87,7 +87,7 @@ static void USBH_UserProcess  (USBH_HandleTypeDef *phost, uint8_t id)
             // Compose vidpid string
             uint16_t vid = phost->device.DevDesc.idVendor;
             uint16_t pid = phost->device.DevDesc.idProduct;
-            printf("USB HID device connected: 0x%04X:%04X\n", vid, pid);
+            printf("USB device connected: 0x%04X:%04X\n", vid, pid);
             memset(vidpid_string, 0, sizeof(vidpid_string));
             snprintf(vidpid_string, sizeof(vidpid_string), "0x%04X:%04X", vid, pid);
             vidpid_string[sizeof(vidpid_string) - 1] = '\0';

--- a/src/usb/usbh_core.h
+++ b/src/usb/usbh_core.h
@@ -58,6 +58,7 @@ extern "C" {
 #define HOST_USER_CONNECTION                    0x04U
 #define HOST_USER_DISCONNECTION                 0x05U
 #define HOST_USER_UNRECOVERED_ERROR             0x06U
+#define HOST_USER_NO_SUPPORTED_CLASS            0x07U
 
 
 /**

--- a/src/usb/usbh_hid.c
+++ b/src/usb/usbh_hid.c
@@ -701,7 +701,7 @@ HID_TypeTypeDef USBH_HID_GetDeviceType(USBH_HandleTypeDef *phost)
         } else if (InterfaceProtocol == HID_MOUSE_BOOT_CODE) {
             type = HID_MOUSE;
         } else {
-            type = HID_MOUSE; // fallback to mouse as well
+            type = HID_UNKNOWN;
         }
     }
     return type;

--- a/src/xlat.c
+++ b/src/xlat.c
@@ -45,7 +45,7 @@ static volatile uint_fast8_t gpio_irq_consumer = 0;
 // SETTINGS
 volatile bool           xlat_initialized = false;
 static xlat_mode_t      xlat_mode = XLAT_MODE_CLICK;
-static bool             hid_using_reportid = false;
+static uint8_t          hid_reportid = 0;
 static bool             auto_trigger_level_high = false;
 static xlat_interface_t xlat_interface = XLAT_INTERFACE_AUTO;
 static uint8_t          found_interface = 0xFF;
@@ -169,6 +169,8 @@ static void hidreport_check_item(HID_ReportItem_t *item)
                         x_location.found = true;
                         x_location.bit_index = item->BitOffset;
                         x_location.bit_size = item->Attributes.BitSize;
+
+                        hid_reportid = item->ReportID;
                     }
                     break;
 
@@ -178,6 +180,8 @@ static void hidreport_check_item(HID_ReportItem_t *item)
                         y_location.found = true;
                         y_location.bit_index = item->BitOffset;
                         y_location.bit_size = item->Attributes.BitSize;
+
+                        hid_reportid = item->ReportID;
                     }
                     break;
             }
@@ -188,6 +192,8 @@ static void hidreport_check_item(HID_ReportItem_t *item)
             if (!key_location.found) {
                 key_location.found = true;
                 key_location.bit_index = item->BitOffset;
+
+                hid_reportid = item->ReportID;
             }
             break;
 
@@ -196,6 +202,8 @@ static void hidreport_check_item(HID_ReportItem_t *item)
             if (!button_location.found) {
                 button_location.found = true;
                 button_location.bit_index = item->BitOffset;
+
+                hid_reportid = item->ReportID;
             }
             break;
 
@@ -268,8 +276,8 @@ static void check_offsets(void)
 {
     printf("\n");
 
-    if (hid_using_reportid) {
-        printf("[*] Using reportId, so actual report data is starting at index [1]\n");
+    if (hid_reportid) {
+        printf("[*] Using reportId '%d', so actual report data is starting at index [1]\n", hid_reportid);
     }
 
     // Only print offsets relevant for a mouse
@@ -280,7 +288,7 @@ static void check_offsets(void)
                 printf("[!] Button found at bit index %d, which is not a multiple of 8. Currently not supported by XLAT.\n", button_location.bit_index);
                 button_location.found = false;
             } else {
-                button_location.byte_offset = button_location.bit_index / 8 + (size_t)hid_using_reportid;
+                button_location.byte_offset = button_location.bit_index / 8 + (hid_reportid ? 1 : 0);
                 printf("[*] Button found at bit index %d, which is byte %d\n", button_location.bit_index, button_location.bit_index / 8);
                 printf("    Button byte offset: %d\n", button_location.byte_offset);
             }
@@ -295,7 +303,7 @@ static void check_offsets(void)
                 printf("[!] X found at bit index %d, which is not a multiple of 8. Currently not supported by XLAT.\n", x_location.bit_index);
                 x_location.found = false;
             } else {
-                x_location.byte_offset = x_location.bit_index / 8 + (size_t)hid_using_reportid;
+                x_location.byte_offset = x_location.bit_index / 8 + (hid_reportid ? 1 : 0);
                 printf("[*] X found at bit index %d, which is byte %d\n", x_location.bit_index, x_location.bit_index / 8);
                 printf("    X size: %d bits, %d bytes\n", x_location.bit_size, x_location.bit_size / 8);
                 printf("    X byte offset: %d\n", x_location.byte_offset);
@@ -315,7 +323,7 @@ static void check_offsets(void)
                     y_location.bit_index);
                 y_location.found = false;
             } else {
-                y_location.byte_offset = y_location.bit_index / 8 + (size_t)hid_using_reportid;
+                y_location.byte_offset = y_location.bit_index / 8 + (hid_reportid ? 1 : 0);
                 printf("[*] Y found at bit index %d, which is byte %d\n", y_location.bit_index, y_location.bit_index / 8);
                 printf("    Y size: %d bits, %d bytes\n", y_location.bit_size, y_location.bit_size / 8);
                 printf("    Y byte offset: %d\n", y_location.byte_offset);
@@ -333,7 +341,7 @@ static void check_offsets(void)
                 printf("[!] Key found at bit index %d, which is not a multiple of 8. Currently not supported by XLAT.\n", key_location.bit_index);
                 key_location.found = false;
             } else {
-                key_location.byte_offset = key_location.bit_index / 8 + (size_t)hid_using_reportid;
+                key_location.byte_offset = key_location.bit_index / 8 + (hid_reportid ? 1 : 0);
                 printf("[*] Key found at bit index %d, which is byte %d\n", key_location.bit_index, key_location.bit_index / 8);
                 printf("    Key byte offset: %d\n", key_location.byte_offset);
             }
@@ -388,7 +396,7 @@ void xlat_usb_hid_event(void)
 
         if (USBH_HID_GetRawData(phost, hid_raw_data) == USBH_OK) {
             // check reportId for ULX
-            if (hid_using_reportid && (hid_raw_data[0] != 0x01)) {
+            if (hid_reportid && (hid_raw_data[0] != hid_reportid)) {
                 // ignore
                 goto out;
             }
@@ -470,7 +478,7 @@ void xlat_usb_hid_event(void)
 
         if (USBH_HID_GetRawData(phost, hid_raw_data) == USBH_OK) {
             // check reportId for ULX
-            if (hid_using_reportid && (hid_raw_data[0] != 0x01)) {
+            if (hid_reportid && (hid_raw_data[0] != hid_reportid)) {
                 // ignore
                 goto out;
             }
@@ -644,14 +652,14 @@ void xlat_reset_latency(void)
     }
 }
 
-void xlat_set_using_reportid(bool use_reportid)
+void xlat_set_reportid(uint8_t reportid)
 {
-    hid_using_reportid = use_reportid;
+    hid_reportid = reportid;
 }
 
-bool xlat_get_using_reportid(void)
+uint8_t xlat_get_reportid(void)
 {
-    return hid_using_reportid;
+    return hid_reportid;
 }
 
 static void xlat_timer_callback(TimerHandle_t xTimer)
@@ -738,8 +746,7 @@ void xlat_parse_hid_descriptor(uint8_t *desc, size_t desc_size)
     }
 
     // Check if using reportIDs:
-    hid_using_reportid = report_info.UsingReportIDs;
-    printf("Using reportIDs: %d\n", hid_using_reportid);
+    printf("Using reportIDs: %d\n", report_info.UsingReportIDs);
 
     // Find click and motion data offsets
     check_offsets();

--- a/src/xlat.h
+++ b/src/xlat.h
@@ -86,8 +86,8 @@ uint32_t xlat_get_last_usb_timestamp_us(void);
 uint32_t xlat_get_last_button_timestamp_us(void);
 
 
-void xlat_set_using_reportid(bool use_reportid);
-bool xlat_get_using_reportid(void);
+void xlat_set_reportid(uint8_t reportid);
+uint8_t xlat_get_reportid(void);
 
 void xlat_parse_hid_descriptor(uint8_t *desc, size_t desc_size);
 


### PR DESCRIPTION
- Fix the usage of reportIDs, before one the reportID one was checked if reportIDs were used
- Show the reportID of the found device
- Correct usage of the current interface number for requests
- Displaying the connected device even when unsupported
- Better identification if a mouse or keyboard is currently searched